### PR TITLE
Add Account Abstraction Layer for contracts (Qtum Core / QTUMCORE-47)

### DIFF
--- a/libethereum/ExtVM.cpp
+++ b/libethereum/ExtVM.cpp
@@ -133,7 +133,8 @@ h160 ExtVM::create(u256 _endowment, u256& io_gas, bytesConstRef _code, OnOpFunc 
 void ExtVM::suicide(Address _a)
 {
 	// TODO: Why transfer is no used here?
-	m_s.addBalance(_a, m_s.balance(myAddress));
-	m_s.subBalance(myAddress, m_s.balance(myAddress));
+	// m_s.addBalance(_a, m_s.balance(myAddress));
+	// m_s.subBalance(myAddress, m_s.balance(myAddress));
+	m_s.transferBalance(myAddress, _a, m_s.balance(myAddress));
 	ExtVMFace::suicide(_a);
 }

--- a/libethereum/State.h
+++ b/libethereum/State.h
@@ -237,7 +237,7 @@ public:
 	 * @param _to Account to which @a _value will be added.
 	 * @param _value Amount to be transferred.
 	 */
-	void transferBalance(Address const& _from, Address const& _to, u256 const& _value) { subBalance(_from, _value); addBalance(_to, _value); }
+	virtual void transferBalance(Address const& _from, Address const& _to, u256 const& _value) { subBalance(_from, _value); addBalance(_to, _value); }
 
 	/// Get the root of the storage of an account.
 	h256 storageRoot(Address const& _contract) const;
@@ -256,7 +256,7 @@ public:
 	void setNewCode(Address const& _address, bytes&& _code);
 
 	/// Delete an account (used for processing suicides).
-	void kill(Address _a);
+	virtual void kill(Address _a);
 
 	/// Get the storage of an account.
 	/// @note This is expensive. Don't use it unless you need to.


### PR DESCRIPTION
The account abstraction layer is a way for EVM contracts to work on the UTXO based blockchain. This story should cover nearly the entire module.
Funds can be sent to a contract using OP_CALL. When a contract receives or sends funds, it should result in a "condensing transaction". This condensing transaction will spend any existing contract vouts which require their balance to be changed, and the outputs will be the new balance of the contracts.
The condensing transaction is created so that a contract never owns more than 1 UTXO. This significantly simplifies coin picking, and prevents many attack vectors with filling up a block.
There can be more than 1 condensing transaction per block. In the case of a single contract having multiple balance changes in a block, a condensing transaction might spend a previous condensing transaction's outputs in the same block. This is slightly wasteful but reduces the complexity of logic required, and allows for easily adding more contract execution transactions without needing to rewrite any previous transactions.
An ITD for the full behavior with all known edge cases is here: https://github.com/qtumproject/qtum-itds/blob/master/aal/condensing-transaction.md