### PR TITLE
Change std::vector to std::set for deleteAddresses

### DIFF
--- a/libethcore/SealEngine.h
+++ b/libethcore/SealEngine.h
@@ -84,7 +84,7 @@ public:
 	virtual bigint costOfPrecompiled(Address const& _a, bytesConstRef _in, u256 const&) const { return m_params.precompiled.at(_a).cost(_in); }
 	virtual std::pair<bool, bytes> executePrecompiled(Address const& _a, bytesConstRef _in, u256 const&) const { return m_params.precompiled.at(_a).execute(_in); }
 
-	mutable std::vector<Address> deleteAddresses; // qtum
+	mutable std::set<Address> deleteAddresses; // qtum
 
 protected:
 	virtual bool onOptionChanging(std::string const&, bytes const&) { return true; }

--- a/libethereum/Executive.cpp
+++ b/libethereum/Executive.cpp
@@ -307,7 +307,7 @@ bool Executive::call(CallParameters const& _p, u256 const& _gasPrice, Address co
 
 	//////////////////////////////////////////////// // qtum
 	if(!m_s.addressInUse(_p.receiveAddress))
-		m_sealEngine.deleteAddresses.push_back(_p.receiveAddress);
+		m_sealEngine.deleteAddresses.insert(_p.receiveAddress);
 	////////////////////////////////////////////////
 
 	// Transfer ether.

--- a/libethereum/ExtVM.cpp
+++ b/libethereum/ExtVM.cpp
@@ -136,7 +136,7 @@ void ExtVM::suicide(Address _a)
 	// m_s.addBalance(_a, m_s.balance(myAddress));
 	// m_s.subBalance(myAddress, m_s.balance(myAddress));
 	if(!m_s.addressInUse(_a)){
-		m_sealEngine.deleteAddresses.push_back(_a);
+		m_sealEngine.deleteAddresses.insert(_a);
 	}
 	m_s.transferBalance(myAddress, _a, m_s.balance(myAddress));
 	ExtVMFace::suicide(_a);


### PR DESCRIPTION
This results in a slight performance decrease for EVM execution(slower insert), but in Qtum's AAL code, it results in a significant performance increase. Overall, this is much safer and less prone to transaction flooding attacks

CreateNewBalances() before: 0.509s
CreateNewBalances() after:  0.026s

Total EVM execution before: 0.171s
Total EVM execution after: 0.189s