### PR TITLE
Don't throw an exception when sender is 0

### DIFF
--- a/libethcore/Transaction.cpp
+++ b/libethcore/Transaction.cpp
@@ -113,7 +113,7 @@ Address const& TransactionBase::sender() const
 	{
 		auto p = recover(m_vrs, sha3(WithoutSignature));
 		if (!p)
-			BOOST_THROW_EXCEPTION(InvalidSignature());
+            return m_sender;
 		m_sender = right160(dev::sha3(bytesConstRef(p.data(), sizeof(p))));
 	}
 	return m_sender;


### PR DESCRIPTION
Sender should be allowed to be 0 when using a non-standard or P2SH output as the first input to the contract execution transaction