### PR TITLE
 Cryptopp link problem in Qtum for Linux

### DIFF
--- a/cmake/ProjectCryptopp.cmake
+++ b/cmake/ProjectCryptopp.cmake
@@ -153,6 +153,7 @@ ExternalProject_Add(cryptopp
         -DCMAKE_BUILD_TYPE=Release
         # Build static lib but suitable to be included in a shared lib.
         -DCMAKE_POSITION_INDEPENDENT_CODE=${BUILD_SHARED_LIBS}
+        -DCMAKE_POSITION_INDEPENDENT_CODE=ON### qtum
         -DBUILD_SHARED=Off
         -DBUILD_TESTING=Off
         -DCMAKE_SYSTEM_NAME=${CMAKE_SYSTEM_NAME}


### PR DESCRIPTION
Fix Linux link problem for `cryptopp` after cross compile evolution.
Set `cryptopp` be always position independent, the same as it is for `secp256k1`.
, 