### PR TITLE
Revert code removal PR and instead use #ifdef guards

### DIFF
--- a/libdevcore/Common.cpp
+++ b/libdevcore/Common.cpp
@@ -22,12 +22,13 @@
 #include "Common.h"
 #include "Exceptions.h"
 #include "Log.h"
+#include "BuildInfo.h"
 using namespace std;
 using namespace dev;
 
 namespace dev
 {
-#define ETH_PROJECT_VERSION "1.3.0"
+
 char const* Version = ETH_PROJECT_VERSION;
 
 const u256 Invalid256 = ~(u256)0;

--- a/libdevcore/Common.cpp
+++ b/libdevcore/Common.cpp
@@ -22,13 +22,17 @@
 #include "Common.h"
 #include "Exceptions.h"
 #include "Log.h"
+#ifndef QTUM_BUILD
 #include "BuildInfo.h"
+#endif
 using namespace std;
 using namespace dev;
 
 namespace dev
 {
-
+#ifdef QTUM_BUILD
+#define ETH_PROJECT_VERSION "1.3.0"
+#endif
 char const* Version = ETH_PROJECT_VERSION;
 
 const u256 Invalid256 = ~(u256)0;

--- a/libdevcore/FileSystem.cpp
+++ b/libdevcore/FileSystem.cpp
@@ -36,9 +36,9 @@
 #include <boost/filesystem.hpp>
 using namespace std;
 using namespace dev;
-
+#ifndef QTUM_BUILD
 static_assert(BOOST_VERSION == 106300, "Wrong boost headers version");
-
+#endif
 // Should be written to only once during startup
 static string s_ethereumDatadir;
 static string s_ethereumIpcPath;

--- a/libdevcore/FileSystem.cpp
+++ b/libdevcore/FileSystem.cpp
@@ -37,6 +37,7 @@
 using namespace std;
 using namespace dev;
 
+static_assert(BOOST_VERSION == 106300, "Wrong boost headers version");
 
 // Should be written to only once during startup
 static string s_ethereumDatadir;

--- a/libdevcore/Log.cpp
+++ b/libdevcore/Log.cpp
@@ -169,6 +169,9 @@ extern "C" __declspec(dllimport) void __stdcall OutputDebugStringA(const char* l
 
 string dev::getThreadName()
 {
+#ifdef QTUM_BUILD
+    return "";
+#else
 #if defined(__GLIBC__) || defined(__APPLE__)
 	char buffer[128];
 	pthread_getname_np(pthread_self(), buffer, 127);
@@ -177,16 +180,19 @@ string dev::getThreadName()
 #else
 	return g_logThreadName.m_name.get() ? *g_logThreadName.m_name.get() : "<unknown>";
 #endif
+#endif
 }
 
 void dev::setThreadName(string const& _n)
 {
+#ifndef QTUM_BUILD
 #if defined(__GLIBC__)
 	pthread_setname_np(pthread_self(), _n.c_str());
 #elif defined(__APPLE__)
 	pthread_setname_np(_n.c_str());
 #else
 	g_logThreadName.m_name.reset(new std::string(_n));
+#endif
 #endif
 }
 

--- a/libdevcore/debugbreak.h
+++ b/libdevcore/debugbreak.h
@@ -100,10 +100,20 @@ enum { HAVE_TRAP_INSTRUCTION = 0, };
 __attribute__((gnu_inline, always_inline))
 static void __inline__ debug_break(void)
 {
-	 /* raises SIGILL on Linux x86{,-64}, to continue in gdb:
-	  * (gdb) handle SIGILL stop nopass
-	  * */
-	__builtin_trap();
+	if (HAVE_TRAP_INSTRUCTION) {
+#if defined(ETH_EMSCRIPTEN)
+		asm("debugger");
+#else
+		trap_instruction();
+#endif
+	} else if (DEBUG_BREAK_PREFER_BUILTIN_TRAP_TO_SIGTRAP) {
+		 /* raises SIGILL on Linux x86{,-64}, to continue in gdb:
+		  * (gdb) handle SIGILL stop nopass
+		  * */
+		__builtin_trap();
+	} else {
+		raise(SIGTRAP);
+	}
 }
 
 #ifdef __cplusplus

--- a/libdevcore/debugbreak.h
+++ b/libdevcore/debugbreak.h
@@ -100,6 +100,9 @@ enum { HAVE_TRAP_INSTRUCTION = 0, };
 __attribute__((gnu_inline, always_inline))
 static void __inline__ debug_break(void)
 {
+#ifdef QTUM_BUILD
+    __builtin_trap();
+#else
 	if (HAVE_TRAP_INSTRUCTION) {
 #if defined(ETH_EMSCRIPTEN)
 		asm("debugger");
@@ -114,6 +117,7 @@ static void __inline__ debug_break(void)
 	} else {
 		raise(SIGTRAP);
 	}
+#endif
 }
 
 #ifdef __cplusplus

--- a/libdevcrypto/Common.cpp
+++ b/libdevcrypto/Common.cpp
@@ -355,7 +355,11 @@ void dev::crypto::ecdh::agree(Secret const& _s, Public const& _r, Secret& o_s)
 	auto r = secp256k1_ec_pubkey_parse(ctx, &rawPubkey, serializedPubKey.data(), serializedPubKey.size());
 	assert(r == 1);
 	std::array<byte, 33> compressedPoint;
-	r = secp256k1_ecdh_raw(ctx, compressedPoint.data(), &rawPubkey, _s.data());
+#ifdef QTUM_BUILD
+    r = secp256k1_ecdh(ctx, compressedPoint.data(), &rawPubkey, _s.data());
+#else
+    r = secp256k1_ecdh_raw(ctx, compressedPoint.data(), &rawPubkey, _s.data());
+#endif
 	assert(r == 1);  // TODO: This should be "invalid secret key" exception.
 	std::copy(compressedPoint.begin() + 1, compressedPoint.end(), o_s.writable().data());
 }

--- a/libdevcrypto/Common.cpp
+++ b/libdevcrypto/Common.cpp
@@ -355,7 +355,7 @@ void dev::crypto::ecdh::agree(Secret const& _s, Public const& _r, Secret& o_s)
 	auto r = secp256k1_ec_pubkey_parse(ctx, &rawPubkey, serializedPubKey.data(), serializedPubKey.size());
 	assert(r == 1);
 	std::array<byte, 33> compressedPoint;
-	r = secp256k1_ecdh(ctx, compressedPoint.data(), &rawPubkey, _s.data());
+	r = secp256k1_ecdh_raw(ctx, compressedPoint.data(), &rawPubkey, _s.data());
 	assert(r == 1);  // TODO: This should be "invalid secret key" exception.
 	std::copy(compressedPoint.begin() + 1, compressedPoint.end(), o_s.writable().data());
 }

--- a/libethash/internal.c
+++ b/libethash/internal.c
@@ -38,40 +38,7 @@
 #include "sha3_cryptopp.h"
 
 #else
-
-
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-#include "compiler.h"
-#include <stdint.h>
-#include <stdlib.h>
-
-struct ethash_h256;
-
-#define decsha3(bits) \
-	int sha3_##bits(uint8_t*, size_t, uint8_t const*, size_t);
-
-decsha3(256)
-decsha3(512)
-
-void SHA3_256(struct ethash_h256 const* ret, uint8_t const* data, size_t const size)
-{
-	sha3_256((uint8_t*)ret, 32, data, size);
-}
-
-void SHA3_512(uint8_t* ret, uint8_t const* data, size_t const size)
-{
-	sha3_512(ret, 64, data, size);
-}
-
-#ifdef __cplusplus
-}
-#endif
-
-
+#include "sha3.h"
 #endif // WITH_CRYPTOPP
 
 uint64_t ethash_get_datasize(uint64_t const block_number)

--- a/libethash/internal.c
+++ b/libethash/internal.c
@@ -38,7 +38,39 @@
 #include "sha3_cryptopp.h"
 
 #else
+#ifndef QTUM_BUILD
 #include "sha3.h"
+#else
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "compiler.h"
+#include <stdint.h>
+#include <stdlib.h>
+
+struct ethash_h256;
+
+#define decsha3(bits) \
+	int sha3_##bits(uint8_t*, size_t, uint8_t const*, size_t);
+
+decsha3(256)
+decsha3(512)
+
+void SHA3_256(struct ethash_h256 const* ret, uint8_t const* data, size_t const size)
+{
+	sha3_256((uint8_t*)ret, 32, data, size);
+}
+
+void SHA3_512(uint8_t* ret, uint8_t const* data, size_t const size)
+{
+	sha3_512(ret, 64, data, size);
+}
+
+#ifdef __cplusplus
+}
+#endif
+#endif //else QTUM_BUILD
 #endif // WITH_CRYPTOPP
 
 uint64_t ethash_get_datasize(uint64_t const block_number)

--- a/libethash/mmap_win32.c
+++ b/libethash/mmap_win32.c
@@ -10,7 +10,7 @@
  * MapViewOfFile:     http://msdn.microsoft.com/en-us/library/aa366761(VS.85).aspx
  * UnmapViewOfFile:   http://msdn.microsoft.com/en-us/library/aa366882(VS.85).aspx
  */
-
+#if defined(__MINGW32__) || defined(_WIN32)
 #include <io.h>
 #include <windows.h>
 #include "mmap.h"
@@ -89,3 +89,5 @@ void munmap(void* addr, size_t length)
 
 #undef DWORD_HI
 #undef DWORD_LO
+
+#endif

--- a/libethash/sha3.h
+++ b/libethash/sha3.h
@@ -16,12 +16,12 @@ struct ethash_h256;
 decsha3(256)
 decsha3(512)
 
-inline void SHA3_256(struct ethash_h256 const* ret, uint8_t const* data, size_t const size)
+static inline void SHA3_256(struct ethash_h256 const* ret, uint8_t const* data, size_t const size)
 {
 	sha3_256((uint8_t*)ret, 32, data, size);
 }
 
-inline void SHA3_512(uint8_t* ret, uint8_t const* data, size_t const size)
+static inline void SHA3_512(uint8_t* ret, uint8_t const* data, size_t const size)
 {
 	sha3_512(ret, 64, data, size);
 }

--- a/libethereum/Executive.cpp
+++ b/libethereum/Executive.cpp
@@ -19,6 +19,7 @@
 #include "Executive.h"
 
 #include <boost/timer.hpp>
+#include <json/json.h>
 #include <libdevcore/CommonIO.h>
 #include <libevm/VMFactory.h>
 #include <libevm/VM.h>
@@ -36,6 +37,7 @@ const char* VMTraceChannel::name() { return "EVM"; }
 const char* ExecutiveWarnChannel::name() { return WarnChannel::name(); }
 
 StandardTrace::StandardTrace():
+	m_trace(Json::arrayValue)
 {}
 
 bool changesMemory(Instruction _inst)
@@ -61,11 +63,82 @@ bool changesStorage(Instruction _inst)
 
 void StandardTrace::operator()(uint64_t _steps, uint64_t PC, Instruction inst, bigint newMemSize, bigint gasCost, bigint gas, VM* voidVM, ExtVMFace const* voidExt)
 {
+	(void)_steps;
 
+	ExtVM const& ext = dynamic_cast<ExtVM const&>(*voidExt);
+	VM& vm = *voidVM;
+
+	Json::Value r(Json::objectValue);
+
+	Json::Value stack(Json::arrayValue);
+	if (!m_options.disableStack)
+	{
+		for (auto const& i: vm.stack())
+			stack.append("0x" + toHex(toCompactBigEndian(i, 1)));
+		r["stack"] = stack;
+	}
+
+	bool newContext = false;
+	Instruction lastInst = Instruction::STOP;
+
+	if (m_lastInst.size() == ext.depth)
+	{
+		// starting a new context
+		assert(m_lastInst.size() == ext.depth);
+		m_lastInst.push_back(inst);
+		newContext = true;
+	}
+	else if (m_lastInst.size() == ext.depth + 2)
+	{
+		m_lastInst.pop_back();
+		lastInst = m_lastInst.back();
+	}
+	else if (m_lastInst.size() == ext.depth + 1)
+	{
+		// continuing in previous context
+		lastInst = m_lastInst.back();
+		m_lastInst.back() = inst;
+	}
+	else
+	{
+		cwarn << "GAA!!! Tracing VM and more than one new/deleted stack frame between steps!";
+		cwarn << "Attmepting naive recovery...";
+		m_lastInst.resize(ext.depth + 1);
+	}
+
+	Json::Value memJson(Json::arrayValue);
+	if (!m_options.disableMemory && (changesMemory(lastInst) || newContext))
+	{
+		for (unsigned i = 0; i < vm.memory().size(); i += 32)
+		{
+			bytesConstRef memRef(vm.memory().data() + i, 32);
+			memJson.append(toHex(memRef, 2, HexPrefix::DontAdd));
+		}
+		r["memory"] = memJson;
+	}
+
+	if (!m_options.disableStorage && (m_options.fullStorage || changesStorage(lastInst) || newContext))
+	{
+		Json::Value storage(Json::objectValue);
+		for (auto const& i: ext.state().storage(ext.myAddress))
+			storage["0x" + toHex(toCompactBigEndian(i.second.first, 1))] = "0x" + toHex(toCompactBigEndian(i.second.second, 1));
+		r["storage"] = storage;
+	}
+
+	if (m_showMnemonics)
+		r["op"] = instructionInfo(inst).name;
+	r["pc"] = toString(PC);
+	r["gas"] = toString(gas);
+	r["gasCost"] = toString(gasCost);
+	if (!!newMemSize)
+		r["memexpand"] = toString(newMemSize);
+
+	m_trace.append(r);
 }
 
 string StandardTrace::json(bool _styled) const
 {
+	return _styled ? Json::StyledWriter().write(m_trace) : Json::FastWriter().write(m_trace);
 }
 
 Executive::Executive(Block& _s, BlockChain const& _bc, unsigned _level):

--- a/libethereum/Executive.cpp
+++ b/libethereum/Executive.cpp
@@ -19,7 +19,9 @@
 #include "Executive.h"
 
 #include <boost/timer.hpp>
+#ifndef QTUM_BUILD
 #include <json/json.h>
+#endif
 #include <libdevcore/CommonIO.h>
 #include <libevm/VMFactory.h>
 #include <libevm/VM.h>
@@ -36,9 +38,14 @@ using namespace dev::eth;
 const char* VMTraceChannel::name() { return "EVM"; }
 const char* ExecutiveWarnChannel::name() { return WarnChannel::name(); }
 
-StandardTrace::StandardTrace():
-	m_trace(Json::arrayValue)
+#ifdef QTUM_BUILD
+StandardTrace::StandardTrace()
 {}
+#else
+StandardTrace::StandardTrace():
+        m_trace(Json::arrayValue)
+{}
+#endif
 
 bool changesMemory(Instruction _inst)
 {
@@ -63,6 +70,9 @@ bool changesStorage(Instruction _inst)
 
 void StandardTrace::operator()(uint64_t _steps, uint64_t PC, Instruction inst, bigint newMemSize, bigint gasCost, bigint gas, VM* voidVM, ExtVMFace const* voidExt)
 {
+#ifdef QTUM_BUILD
+    return;
+#else
 	(void)_steps;
 
 	ExtVM const& ext = dynamic_cast<ExtVM const&>(*voidExt);
@@ -134,11 +144,16 @@ void StandardTrace::operator()(uint64_t _steps, uint64_t PC, Instruction inst, b
 		r["memexpand"] = toString(newMemSize);
 
 	m_trace.append(r);
+#endif
 }
 
 string StandardTrace::json(bool _styled) const
 {
+#ifdef QTUM_BUILD
+    return "";
+#else
 	return _styled ? Json::StyledWriter().write(m_trace) : Json::FastWriter().write(m_trace);
+#endif
 }
 
 Executive::Executive(Block& _s, BlockChain const& _bc, unsigned _level):

--- a/libethereum/Executive.cpp
+++ b/libethereum/Executive.cpp
@@ -35,7 +35,7 @@ using namespace dev::eth;
 const char* VMTraceChannel::name() { return "EVM"; }
 const char* ExecutiveWarnChannel::name() { return WarnChannel::name(); }
 
-StandardTrace::StandardTrace()
+StandardTrace::StandardTrace():
 {}
 
 bool changesMemory(Instruction _inst)
@@ -66,7 +66,6 @@ void StandardTrace::operator()(uint64_t _steps, uint64_t PC, Instruction inst, b
 
 string StandardTrace::json(bool _styled) const
 {
-	return "";
 }
 
 Executive::Executive(Block& _s, BlockChain const& _bc, unsigned _level):

--- a/libethereum/Executive.h
+++ b/libethereum/Executive.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <functional>
+#include <json/json.h>
 #include <libdevcore/Log.h>
 #include <libevmcore/Instruction.h>
 #include <libethcore/Common.h>
@@ -73,6 +74,7 @@ private:
 	bool m_showMnemonics = false;
 	std::vector<Instruction> m_lastInst;
 	bytes m_lastCallData;
+	Json::Value m_trace;
 	DebugOptions m_options;
 };
 

--- a/libethereum/Executive.h
+++ b/libethereum/Executive.h
@@ -19,7 +19,9 @@
 #pragma once
 
 #include <functional>
+#ifndef QTUM_BUILD
 #include <json/json.h>
+#endif
 #include <libdevcore/Log.h>
 #include <libevmcore/Instruction.h>
 #include <libethcore/Common.h>
@@ -74,7 +76,9 @@ private:
 	bool m_showMnemonics = false;
 	std::vector<Instruction> m_lastInst;
 	bytes m_lastCallData;
+#ifndef QTUM_BUILD
 	Json::Value m_trace;
+#endif
 	DebugOptions m_options;
 };
 

--- a/libethereum/State.cpp
+++ b/libethereum/State.cpp
@@ -26,7 +26,9 @@
 #include <boost/timer.hpp>
 #include <libdevcore/CommonIO.h>
 #include <libdevcore/Assertions.h>
+#ifndef QTUM_BUILD
 #include <libdevcore/TrieHash.h>
+#endif
 #include <libevmcore/Instruction.h>
 #include <libethcore/Exceptions.h>
 #include <libevm/VMFactory.h>

--- a/libethereum/State.cpp
+++ b/libethereum/State.cpp
@@ -30,7 +30,6 @@
 #include <libevmcore/Instruction.h>
 #include <libethcore/Exceptions.h>
 #include <libevm/VMFactory.h>
-#include <libdevcore/TrieDB.h>
 #include "BlockChain.h"
 #include "CodeSizeCache.h"
 #include "Defaults.h"


### PR DESCRIPTION
This makes it so that the code is different only when compiled within Qtum's build process. This allows us to still compile and run all of the tests of cpp-eth as well as makes future upstream merges easier