### PR TITLE
Disable the EVM CREATE opcode

### DIFF
--- a/libevm/VM.cpp
+++ b/libevm/VM.cpp
@@ -202,7 +202,7 @@ void VM::interpretCases()
 		
 		CASE(CREATE)
 		{
-			m_bounce = &VM::caseCreate;
+            throwBadInstruction();
 		}
 		BREAK;
 


### PR DESCRIPTION
This should be disabled for Qtum. There is very little real practical use for being able to create contracts within contracts, and it is a large task to make this functionality work properly in Qtum's model. It would not be so difficult to create the OP_CREATE opcode, but it is impossible in this model to create a contract which contains coins initially, because OP_CREATE opcodes can contain value, but cannot be spent by the contract. We will evaluate if this is worth fixing in 2018 with the first hard-fork to add new features