### PR TITLE
Update type conversion for boost1.67

### DIFF
--- a/libdevcore/RLP.h
+++ b/libdevcore/RLP.h
@@ -451,7 +451,7 @@ private:
 		m_out.resize(m_out.size() + _br);
 		byte* b = &m_out.back();
 		for (; _i; _i >>= 8)
-			*(b--) = (byte)_i;
+			*(b--) = static_cast<byte>(_i & 0x00000000000000000000000000000000000000000000000000000000000000FF);
 	}
 
 	/// Our output byte stream.


### PR DESCRIPTION
The problem was that in boost 1.67 multiprecision library was updated. It affected the work of variables u256.
Specific changes in this library were changes in the conversion of types from a larger type to a smaller one.
As a result the type conversions in RLP.h and qtumDGP.cpp were changed.
Also found problem with QtumDGP :: checkLimitSchedule (fixed now)
https://svn.boost.org/trac10/ticket/13109