### PR TITLE
Add fix for Boost 1.67

### DIFF
--- a/libdevcore/Common.h
+++ b/libdevcore/Common.h
@@ -119,6 +119,7 @@ using bytesSec = secure_vector<byte>;
 
 // Numeric types.
 using bigint = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<>>;
+using u8 =  boost::multiprecision::number<boost::multiprecision::cpp_int_backend<8, 8, boost::multiprecision::unsigned_magnitude, boost::multiprecision::unchecked, void>>;
 using u64 =  boost::multiprecision::number<boost::multiprecision::cpp_int_backend<64, 64, boost::multiprecision::unsigned_magnitude, boost::multiprecision::unchecked, void>>;
 using u128 =  boost::multiprecision::number<boost::multiprecision::cpp_int_backend<128, 128, boost::multiprecision::unsigned_magnitude, boost::multiprecision::unchecked, void>>;
 using u256 =  boost::multiprecision::number<boost::multiprecision::cpp_int_backend<256, 256, boost::multiprecision::unsigned_magnitude, boost::multiprecision::unchecked, void>>;
@@ -193,6 +194,17 @@ template <size_t n> inline u256 exp10()
 template <> inline u256 exp10<0>()
 {
 	return u256(1);
+}
+
+/// Converts given multiprecision number to standard number type
+template <typename T> uint64_t toUint64(T _u)
+{
+	return static_cast<uint64_t>(u64(_u));
+}
+
+template <typename T> uint8_t toUint8(T _u)
+{
+	return static_cast<uint8_t>(u8(_u));
 }
 
 /// @returns the absolute distance between _a and _b.

--- a/libdevcore/RLP.h
+++ b/libdevcore/RLP.h
@@ -451,7 +451,7 @@ private:
 		m_out.resize(m_out.size() + _br);
 		byte* b = &m_out.back();
 		for (; _i; _i >>= 8)
-			*(b--) = (byte)_i;
+			*(b--) = toUint8(_i);
 	}
 
 	/// Our output byte stream.


### PR DESCRIPTION
The problem is different overflow solutions in `Boost 1.67` for conversion between multiprecision and other numbers.