### PR TITLE
Remove const from nonce

### DIFF
--- a/libethash/internal.c
+++ b/libethash/internal.c
@@ -328,7 +328,7 @@ static bool ethash_hash(
 void ethash_quick_hash(
 	ethash_h256_t* return_hash,
 	ethash_h256_t const* header_hash,
-	uint64_t const nonce,
+	uint64_t nonce,
 	ethash_h256_t const* mix_hash
 )
 {


### PR DESCRIPTION
Since nonce is modified when fixing endianness, it can't be set to const.