### PR TITLE
Throw CreateWithValue after gas update

### DIFF
--- a/libaleth-interpreter/VMCalls.cpp
+++ b/libaleth-interpreter/VMCalls.cpp
@@ -114,10 +114,6 @@ void VM::caseCreate()
     u256 const initOff = m_SP[1];
     u256 const initSize = m_SP[2];
 
-#ifdef QTUM_BUILD
-    if (endowment) BOOST_THROW_EXCEPTION(CreateWithValue());
-#endif
-
     u256 salt;
     if (m_OP == Instruction::CREATE2)
     {
@@ -128,6 +124,10 @@ void VM::caseCreate()
 
     updateMem(memNeed(initOff, initSize));
     updateIOGas();
+
+#ifdef QTUM_BUILD
+    if (endowment) BOOST_THROW_EXCEPTION(CreateWithValue());
+#endif
 
     // Clear the return data buffer. This will not free the memory.
     m_returnData.clear();


### PR DESCRIPTION
Throw `CreateWithValue` after the gas update in `libaleth-interpreter/VMCalls.cpp`.
Modifications in order to throw from the same locations in the code as in `libevm/LegacyVMCalls.cpp`.
The code is moved a few lines below so there will be the same implementation for `caseCreate` in both files. Spotted during review of the HF. No problem detected since will throw exception in both cases.