### PR TITLE
Reduce the max needed glibc version to 2.11

### DIFF
--- a/libethashseal/genesis/qtumMainNetwork.cpp
+++ b/libethashseal/genesis/qtumMainNetwork.cpp
@@ -20,7 +20,7 @@ static dev::h256 const c_genesisStateRootQtumMainNetwork("2ebd2f054ed409f4bc7792
 static std::string const c_genesisInfoQtumMainNetwork = std::string() +
 R"E(
 {
-	"sealEngine": "Ethash",
+	"sealEngine": "NoProof",
 	"params": {
 		"accountStartNonce": "0x00",
 		"homesteadForkBlock": "0x00",

--- a/libethashseal/genesis/test/qtumTestNetwork.cpp
+++ b/libethashseal/genesis/test/qtumTestNetwork.cpp
@@ -20,7 +20,7 @@ static dev::h256 const c_genesisStateRootQtumTestNetwork("2ebd2f054ed409f4bc7792
 static std::string const c_genesisInfoQtumTestNetwork = std::string() +
 R"E(
 {
-	"sealEngine": "Ethash",
+	"sealEngine": "NoProof",
 	"params": {
 		"accountStartNonce": "0x00",
 		"homesteadForkBlock": "0x00",


### PR DESCRIPTION
Remove not used mining code from EVM due to threads that require higher version of glibc.