### PR TITLE
Backport boost 1.75 fix for aleth 1.8

### DIFF
--- a/libethereum/BlockChain.cpp
+++ b/libethereum/BlockChain.cpp
@@ -1617,6 +1617,22 @@ VerifiedBlockRef BlockChain::verifyBlock(bytesConstRef _block, std::function<voi
     return res;
 }
 
+template <class T>
+inline
+boost::exception_ptr
+boost_copy_exception( T const & e )
+{
+    try
+    {
+        throw boost::enable_current_exception(e);
+    }
+    catch(
+    ... )
+    {
+        return boost::current_exception();
+    }
+}
+
 void BlockChain::setChainStartBlockNumber(unsigned _number)
 {
     h256 const hash = numberHash(_number);
@@ -1632,7 +1648,7 @@ void BlockChain::setChainStartBlockNumber(unsigned _number)
     {
         BOOST_THROW_EXCEPTION(FailedToWriteChainStart()
                               << errinfo_hash256(hash)
-                              << boost::errinfo_nested_exception(boost::copy_exception(ex)));
+                              << boost::errinfo_nested_exception(boost_copy_exception(ex)));
     }
 }
 


### PR DESCRIPTION
The new implementation of `boost::copy_exception` in boost 1.75 is not able to copy exception that is described by the base abstract class, can copy only exception from non abstract class.
The old implementation work with both cases, the code used in the fix is from the following link:
https://www.boost.org/doc/libs/1_57_0/libs/exception/doc/copy_exception.html